### PR TITLE
 [RTC-216/217] Allow token to be set in config and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,11 @@ end
 
 ## Usage
 
-Make API calls to Jellyfish:
+Make API calls to Jellyfish (authentication required, for more information see [Jellyfish docs](https://jellyfish-dev.github.io/jellyfish-docs/getting_started/authentication)):
 
 ```elixir
-client = Jellyfish.Client.new("http://address-of-your-server.com")
+# create client instance used in other functions to make the HTTP requests
+client = Jellyfish.Client.new("http://address-of-your-server.com", "your-jellyfish-token")
 
 # Create room
 {:ok, %Jellyfish.Room{id: room_id}} = Jellyfish.Room.create(client, max_peers: 10)
@@ -36,7 +37,7 @@ room_id
 # => "8878cd13-99a6-40d6-8d7e-8da23d803dab"
 
 # Add peer
-{:ok, %Jellyfish.Peer{id: peer_id}, token} = Jellyfish.Room.add_peer(client, room_id, "webrtc")
+{:ok, %Jellyfish.Peer{id: peer_id}, client_token} = Jellyfish.Room.add_peer(client, room_id, "webrtc")
 
 # Delete peer
 :ok = Jellyfish.Room.delete_peer(client, room_id, peer_id)

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ room_id
 # => "8878cd13-99a6-40d6-8d7e-8da23d803dab"
 
 # Add peer
-{:ok, %Jellyfish.Peer{id: peer_id}, client_token} = Jellyfish.Room.add_peer(client, room_id, "webrtc")
+{:ok, %Jellyfish.Peer{id: peer_id}, peer_token} = Jellyfish.Room.add_peer(client, room_id, "webrtc")
 
 # Delete peer
 :ok = Jellyfish.Room.delete_peer(client, room_id, peer_id)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ end
 Make API calls to Jellyfish (authentication required, for more information see [Jellyfish docs](https://jellyfish-dev.github.io/jellyfish-docs/getting_started/authentication)):
 
 ```elixir
-# create client instance used in other functions to make the HTTP requests
 client = Jellyfish.Client.new("http://address-of-your-server.com", "your-jellyfish-token")
 
 # Create room

--- a/lib/jellyfish/client.ex
+++ b/lib/jellyfish/client.ex
@@ -30,10 +30,11 @@ defmodule Jellyfish.Client do
   Creates new instance of `t:Jellyfish.SDK.Client.t/0`.
 
   ```
-  #config.exs
+  # in config.exs
   config :jellyfish_server_sdk, token: "your-jellyfish-token"
 
   client = Jellyfish.Client.new("http://address-of-your-server.com")
+
   # or pass the token explicitly
   client = Jellyfish.Client.new("http://address-of-your-server.com", "your-jellyfish-token")
   ```

--- a/lib/jellyfish/client.ex
+++ b/lib/jellyfish/client.ex
@@ -33,8 +33,7 @@ defmodule Jellyfish.Client do
 
     * `address` - url or IP address of the Jellyfish server instance
     * `token` - token used for authorizing HTTP requests. It's the same
-    token as the one configured in Jellyfish. If not passed, value set via
-    `config :jellyfish_server_sdk, token: "your-token"` in `config.exs` is used.
+    token as the one configured in Jellyfish.
   """
   @spec new(String.t(), String.t()) :: t()
   def new(address, token), do: build_client(address, token)

--- a/lib/jellyfish/client.ex
+++ b/lib/jellyfish/client.ex
@@ -27,17 +27,7 @@ defmodule Jellyfish.Client do
         }
 
   @doc """
-  Creates new instance of `t:Jellyfish.SDK.Client.t/0`.
-
-  ```
-  # in config.exs
-  config :jellyfish_server_sdk, token: "your-jellyfish-token"
-
-  client = Jellyfish.Client.new("http://address-of-your-server.com")
-
-  # or pass the token explicitly
-  client = Jellyfish.Client.new("http://address-of-your-server.com", "your-jellyfish-token")
-  ```
+  Creates new instance of `t:Jellyfish.Client.t/0`.
 
   ## Parameters
 
@@ -46,15 +36,27 @@ defmodule Jellyfish.Client do
     token as the one configured in Jellyfish. If not passed, value set via
     `config :jellyfish_server_sdk, token: "your-token"` in `config.exs` is used.
   """
-  @spec new(String.t(), String.t() | nil) :: t()
-  def new(address, token \\ nil)
+  @spec new(String.t(), String.t()) :: t()
+  def new(address, token), do: build_client(address, token)
 
-  def new(address, nil) do
+  @doc """
+  Creates new instance of `t:Jellyfish.Client.t/0`.
+
+  Uses token set in `config.exs`. To explicitly pass the token, see `new/2`.
+  ```
+  # in config.exs
+  config :jellyfish_server_sdk, token: "your-jellyfish-token"
+
+  client = Jellyfish.Client.new("http://address-of-your-server.com")
+  ```
+
+  See `new/2` for description of parameters.
+  """
+  @spec new(String.t()) :: t()
+  def new(address) do
     token = Application.fetch_env!(:jellyfish_server_sdk, :token)
     build_client(address, token)
   end
-
-  def new(address, token), do: build_client(address, token)
 
   defp build_client(address, token) do
     middleware = [

--- a/lib/jellyfish/client.ex
+++ b/lib/jellyfish/client.ex
@@ -29,14 +29,33 @@ defmodule Jellyfish.Client do
   @doc """
   Creates new instance of `t:Jellyfish.SDK.Client.t/0`.
 
+  ```
+  #config.exs
+  config :jellyfish_server_sdk, token: "your-jellyfish-token"
+
+  client = Jellyfish.Client.new("http://address-of-your-server.com")
+  # or pass the token explicitly
+  client = Jellyfish.Client.new("http://address-of-your-server.com", "your-jellyfish-token")
+  ```
+
   ## Parameters
 
     * `address` - url or IP address of the Jellyfish server instance
     * `token` - token used for authorizing HTTP requests. It's the same
-    token as the one configured in Jellyfish.
+    token as the one configured in Jellyfish. If not passed, value set via
+    `config :jellyfish_server_sdk, token: "your-token"` in `config.exs` is used.
   """
-  @spec new(String.t(), String.t()) :: t()
-  def new(address, token) do
+  @spec new(String.t(), String.t() | nil) :: t()
+  def new(address, token \\ nil)
+
+  def new(address, nil) do
+    token = Application.fetch_env!(:jellyfish_server_sdk, :token)
+    build_client(address, token)
+  end
+
+  def new(address, token), do: build_client(address, token)
+
+  defp build_client(address, token) do
     middleware = [
       {Tesla.Middleware.BaseUrl, address},
       {Tesla.Middleware.BearerAuth, token: token},

--- a/lib/jellyfish/component.ex
+++ b/lib/jellyfish/component.ex
@@ -26,10 +26,9 @@ defmodule Jellyfish.Component do
   """
   @type type :: String.t()
 
-  # TODO update to proper link when it's done
   @typedoc """
   Type describing component options.
-  For the list of available options, please refer to the [component's documentation](https://jellyfish-dev.github.io/jellyfish-docs/).
+  For the list of available options, please refer to the [documentation](https://jellyfish-dev.github.io/jellyfish-docs/).
   """
   @type options :: Keyword.t()
 

--- a/lib/jellyfish/room.ex
+++ b/lib/jellyfish/room.ex
@@ -43,7 +43,7 @@ defmodule Jellyfish.Room do
   @typedoc """
   Client token, created by Jellyfish. Required by client application to open connection to Jellyfish.
   """
-  @type client_token :: String.t()
+  @type peer_token :: String.t()
 
   @typedoc """
   Type describing room options.
@@ -128,7 +128,7 @@ defmodule Jellyfish.Room do
   Add a peer to the room with `room_id`.
   """
   @spec add_peer(Client.t(), id(), Peer.type()) ::
-          {:ok, Peer.t(), client_token()} | {:error, atom() | String.t()}
+          {:ok, Peer.t(), peer_token()} | {:error, atom() | String.t()}
   def add_peer(client, room_id, type) do
     with {:ok, %Env{status: 201, body: body}} <-
            Tesla.post(

--- a/lib/jellyfish/room.ex
+++ b/lib/jellyfish/room.ex
@@ -39,7 +39,7 @@ defmodule Jellyfish.Room do
   Id of the room, unique within Jellyfish instance.
   """
   @type id :: String.t()
-  
+
   @typedoc """
   Client token, created by Jellyfish. Required by client application to open connection to Jellyfish.
   """
@@ -127,7 +127,8 @@ defmodule Jellyfish.Room do
   @doc """
   Add a peer to the room with `room_id`.
   """
-  @spec add_peer(Client.t(), id(), Peer.type()) :: {:ok, Peer.t(), client_token()} | {:error, atom() | String.t()}
+  @spec add_peer(Client.t(), id(), Peer.type()) ::
+          {:ok, Peer.t(), client_token()} | {:error, atom() | String.t()}
   def add_peer(client, room_id, type) do
     with {:ok, %Env{status: 201, body: body}} <-
            Tesla.post(

--- a/lib/jellyfish/room.ex
+++ b/lib/jellyfish/room.ex
@@ -39,6 +39,11 @@ defmodule Jellyfish.Room do
   Id of the room, unique within Jellyfish instance.
   """
   @type id :: String.t()
+  
+  @typedoc """
+  Client token, created by Jellyfish. Required by client application to open connection to Jellyfish.
+  """
+  @type client_token :: String.t()
 
   @typedoc """
   Type describing room options.
@@ -122,7 +127,7 @@ defmodule Jellyfish.Room do
   @doc """
   Add a peer to the room with `room_id`.
   """
-  @spec add_peer(Client.t(), id(), Peer.type()) :: {:ok, Peer.t()} | {:error, atom() | String.t()}
+  @spec add_peer(Client.t(), id(), Peer.type()) :: {:ok, Peer.t(), client_token()} | {:error, atom() | String.t()}
   def add_peer(client, room_id, type) do
     with {:ok, %Env{status: 201, body: body}} <-
            Tesla.post(


### PR DESCRIPTION
This PR contains [RTC-126](https://membraneframework.atlassian.net/jira/software/c/projects/RTC/boards/18?modal=detail&selectedIssue=RTC-216) and [RTC-217](https://membraneframework.atlassian.net/jira/software/c/projects/RTC/boards/18?modal=detail&selectedIssue=RTC-217) as they are closely related.

[RTC-126]: https://membraneframework.atlassian.net/browse/RTC-126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RTC-217]: https://membraneframework.atlassian.net/browse/RTC-217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ